### PR TITLE
Fix: Run production on Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation
- Production was crashing on Fly because the app uses the built-in module `node:sqlite`, which requires Node 22+, so the runtime image must be upgraded.

### Description
- Updated the Docker runtime base image in `Dockerfile` from `FROM node:20-alpine` to `FROM node:22-alpine` and made no other code, dependency, or configuration changes; confirmed `package.json` already has an `engines` entry of `"node": ">=22"`.

### Testing
- Inspected the updated `Dockerfile` and `package.json` to validate the change and confirmed only `Dockerfile` was modified, and attempted to run `docker build` but the `docker` CLI is not available in this environment so a full image build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a11e35274483309f6c9a6e080d4918)